### PR TITLE
Remove unused `n_filters`

### DIFF
--- a/FC-DenseNet.py
+++ b/FC-DenseNet.py
@@ -91,7 +91,6 @@ class Network():
             l = BN_ReLU_Conv(stack, growth_rate, dropout_p=dropout_p)
             block_to_upsample.append(l)
             stack = ConcatLayer([stack, l])
-            n_filters += growth_rate
 
         #######################
         #   Upsampling path   #
@@ -106,7 +105,6 @@ class Network():
             block_to_upsample = []
             for j in range(n_layers_per_block[n_pool + i + 1]):
                 l = BN_ReLU_Conv(stack, growth_rate, dropout_p=dropout_p)
-                n_filters += growth_rate
                 block_to_upsample.append(l)
                 stack = ConcatLayer([stack, l])
 


### PR DESCRIPTION
`n_filters` is not used after the downsample path so no need to keep incrementing it. Also unclear what the incremented value would even mean since `n_filters_keep` is now used.