### PR TITLE
No need to declare a var for the output of the network

### DIFF
--- a/FC-DenseNet.py
+++ b/FC-DenseNet.py
@@ -42,7 +42,6 @@ class Network():
 
         # Theano variables
         self.input_var = T.tensor4('input_var', dtype='float32')  # input image
-        self.output_var = T.tensor4('output_var', dtype='float32')  # output of the network
         self.target_var = T.tensor4('target_var', dtype='int32')  # target
 
         #####################


### PR DESCRIPTION
Right now what you want is stored in `self.output_layer` (or `get_output(self.output_layer)`)